### PR TITLE
Added a skipInstructions method

### DIFF
--- a/raw/squeek/asmhelper/ASMHelper.java
+++ b/raw/squeek/asmhelper/ASMHelper.java
@@ -11,9 +11,11 @@ import java.util.Map;
 import net.minecraft.launchwrapper.LaunchClassLoader;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.JumpInsnNode;
 import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -389,7 +391,7 @@ public class ASMHelper
 	}
 
 	/**
-	 * Remove instructions from {@link insnList} starting with {@link startInvlusive} 
+	 * Remove instructions from {@link insnList} starting with {@link startInclusive} 
 	 * up until reaching {@link endNotInclusive} ({@link endNotInclusive} will not be removed).
 	 * 
 	 * @return The number of instructions removed
@@ -406,6 +408,24 @@ public class ASMHelper
 		}
 		return numDeleted;
 	}
+
+	/**
+	 * Note: This is an alternative to {@link #removeFromInsnListUntil(InsnList, AbstractInsnNode, AbstractInsnNode) removeFromInsnListUntil} and will achieve a similar result. <br>
+	 * <br>
+	 * 
+	 * Skip instructions from {@link insnList} starting with {@link startInclusive}
+	 * up until reaching {@link endNotInclusive} ({@link endNotInclusive} will not be skipped).
+	 *
+	 * This is achieved by inserting a GOTO instruction before {@link startInclusive} which is branched to a
+	 * LabelNode that is inserted before {@link endNotInclusive}.
+	 */
+	public static void skipInstructions(InsnList insnList, AbstractInsnNode startInclusive, AbstractInsnNode endNotInclusive)
+    	{
+        	LabelNode skipLabel = new LabelNode();
+        	JumpInsnNode gotoInsn = new JumpInsnNode(Opcodes.GOTO, skipLabel);
+        	insnList.insertBefore(startInclusive, gotoInsn);
+        	insnList.insertBefore(endNotInclusive, skipLabel);
+    	}
 
 	/**
 	 * Note: Does not move the instruction, but rather gets the instruction a certain


### PR DESCRIPTION
Added a skipInstructions method. Also a tiny fix to a misspelt word in the removeFromInsnListUntil javadoc

The aim of skipInstructions is to provide a much more efficient and more compatible alternative to removeFromInsnListUntil.
- Efficiency:
  Compared to removeFromInsnListUntil, this does not iterate over a loop in our code.
  Will not impact what is on the stack and will still have the same effect on the stack/local variable table compared to removeFromInsnListUntil
- Compatibility:
  If another mod uses ASM on the same class they may wish to find a node that you have removed. Using skipInstructions instead will mean that the nodes are still there and so it reduces the chance of a crash because the mod was unable to transform a missing node.

Other notes:
I have not added a return type for this as I was not sure what you would want to have returned. Also I haven't added any tests for it so you can add them if you wish. I can confirm that this method works however and have been testing skipInstructions in my own mod
