### PR TITLE
Fix a ClassCastException in the  'eclipseClasspath' gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ if (rootProject != project)
 	rootProject.dependencies {
 		submodule project(path: ':ASMHelper')
 	}
-	rootProject.eclipse.classpath.plusConfigurations += rootProject.configurations.submodule
+	rootProject.eclipse.classpath.plusConfigurations += [rootProject.configurations.submodule]
 	rootProject.idea { module { scopes.COMPILE.plus += [rootProject.configurations.submodule] } }
 }
 else


### PR DESCRIPTION
As written, Gradle is attempting to load the file as `java.io.File` when it needs to be a Gradle config file `org.gradle.api.artifacts.Configuration`. Simply putting it in brackets fixes the issue.
