### PR TITLE
Optimize doesClassImplement performance by caching

### DIFF
--- a/raw/squeek/asmhelper/ASMHelper.java
+++ b/raw/squeek/asmhelper/ASMHelper.java
@@ -1,5 +1,8 @@
 package squeek.asmhelper;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
@@ -11,18 +14,23 @@ import org.objectweb.asm.util.Printer;
 import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceMethodVisitor;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class ASMHelper
 {
 	public static InsnComparator insnComparator = new InsnComparator();
+	private static final Multimap<String, String> interfaceLookupCache = HashMultimap.create();
 
 	/**
 	 * Converts a class name to an internal class name.
@@ -160,28 +168,40 @@ public class ASMHelper
 		return classReader.getSuperName() != null && !classReader.getSuperName().equals("java/lang/Object");
 	}
 
-	/**
-	 * @return Whether or not the class read by the ClassReader implements the specified interface.
-	 */
-	public static boolean doesClassImplement(ClassReader classReader, String targetInterfaceInternalClassName)
+	private static Collection<String> findAllInterfaces(ClassReader classReader)
 	{
-		List<String> immediateInterfaces = Arrays.asList(classReader.getInterfaces());
-		for (String immediateInterface : immediateInterfaces)
-		{
-			if (ObfHelper.getInternalClassName(immediateInterface).equals(targetInterfaceInternalClassName))
-				return true;
-		}
+		// TODO: Find interfaces inside interfaces
+		Set<String> interfaces = Sets.newHashSet(classReader.getInterfaces());
 
 		try
 		{
 			if (classHasSuper(classReader))
-				return doesClassImplement(getClassReaderForClassName(ObfHelper.getInternalClassName(classReader.getSuperName())), targetInterfaceInternalClassName);
+			{
+				String className2 = ObfHelper.getInternalClassName(classReader.getSuperName());
+				if (interfaceLookupCache.containsKey(className2))
+					interfaces.addAll(interfaceLookupCache.get(className2));
+				else
+					interfaces.addAll(findAllInterfaces(getClassReaderForClassName(className2)));
+			}
 		}
 		catch (IOException e)
 		{
 			// This will trigger when the super class is abstract; just ignore the error
 		}
-		return false;
+
+		interfaceLookupCache.putAll(classReader.getClassName(), interfaces);
+		return interfaces;
+	}
+
+	/**
+	 * @return Whether or not the class read by the ClassReader implements the specified interface.
+	 */
+	public static boolean doesClassImplement(ClassReader classReader, String targetInterfaceInternalClassName)
+	{
+		if (!interfaceLookupCache.containsKey(classReader.getClassName()))
+			findAllInterfaces(classReader);
+
+		return interfaceLookupCache.get(classReader.getClassName()).contains(targetInterfaceInternalClassName);
 	}
 
 	/**


### PR DESCRIPTION
On a modpack with just Forge and AppleCore, this makes AppleCore's ASM transformation time drop from ~900ms to ~300ms (a ~67% reduction); I expect similar amounts of reduction for larger kitchen sink modpacks where AppleCore takes up ~2000ms.